### PR TITLE
fix: Grammar syntax error on docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Pushgateway-cleaner is configured entirely through environmetn variables.
 | ----------------------------| ---------------|-------------|
 | CLEANER_EXPIRATION_DURATION | 24h            | Metric groups whose last push timestamp is older that this value are deleted. Accepted format {hours}h{Minutes}m{Seconds}s i.e. 1h30m20s, 1h, 10m |
 | CLEANER_CLEANING_INTERVAL   | 12h            | Defines how often to start the cleaning routine.| 
-| CLEANER_ENDPOINT            | localhost:9091 | Prometheu's pushgateway endpoint. |
+| CLEANER_ENDPOINT            | localhost:9091 | Prometheus' pushgateway endpoint. |
 | CLEANER_LOG_LVL             | INFO           | One of DEBUG, INFO, ERROR, WARNING. |
 | CLEANER_DRY_RUN             |"FALSE"         |Set to "TRUE" to dry-run and see which metric groups would be deleted.|
 


### PR DESCRIPTION
In this commit we fix the Prometheus quotation mark in the docs.
Reference: https://www.dailywritingtips.com/quotation-marks-and-apostrophe-s/