### PR TITLE
Upgrade to alpine 3.21 to fix CVE 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-alpine3.15
+FROM python:3.9-alpine3.21
 
 RUN addgroup -S python && adduser -u 999 -S python -G python
 


### PR DESCRIPTION
Hi @konnoska 

I have scanned the image with the trivy, showing the following CVE, CVE-2022-43680,   CVE-2023-29491 CVE-2022-4450
. 

Those 3 CVEs could be fixed by upgrade to alpine 3.21 and can you help to check it?


I've included the details below.


```
┌───────────────────────┬────────────────┬──────────┬────────┬───────────────────┬──────────────────┬─────────────────────────────────────────────────────────────┐
│        Library        │ Vulnerability  │ Severity │ Status │ Installed Version │  Fixed Version   │                            Title                            │
├───────────────────────┼────────────────┼──────────┼────────┼───────────────────┼──────────────────┼─────────────────────────────────────────────────────────────┤
│ expat                 │ CVE-2022-43680 │ HIGH     │ fixed  │ 2.4.9-r0          │ 2.5.0-r0         │ expat: use-after free caused by overeager destruction of a  │
│                       │                │          │        │                   │                  │ shared DTD in...                                            │
│                       │                │          │        │                   │                  │ https://avd.aquasec.com/nvd/cve-2022-43680                  │
├───────────────────────┼────────────────┤          │        ├───────────────────┼──────────────────┼─────────────────────────────────────────────────────────────┤
│ krb5-libs             │ CVE-2022-42898 │          │        │ 1.19.3-r0         │ 1.19.4-r0        │ krb5: integer overflow vulnerabilities in PAC parsing       │
│                       │                │          │        │                   │                  │ https://avd.aquasec.com/nvd/cve-2022-42898                  │
├───────────────────────┼────────────────┤          │        ├───────────────────┼──────────────────┼─────────────────────────────────────────────────────────────┤
│ libcom_err            │ CVE-2022-1304  │          │        │ 1.46.4-r0         │ 1.46.6-r0        │ e2fsprogs: out-of-bounds read/write via crafted filesystem  │
│                       │                │          │        │                   │                  │ https://avd.aquasec.com/nvd/cve-2022-1304                   │
├───────────────────────┼────────────────┤          │        ├───────────────────┼──────────────────┼─────────────────────────────────────────────────────────────┤
│ libcrypto1.1          │ CVE-2022-4450  │          │        │ 1.1.1q-r0         │ 1.1.1t-r0        │ openssl: double free after calling PEM_read_bio_ex          │
│                       │                │          │        │                   │                  │ https://avd.aquasec.com/nvd/cve-2022-4450                   │
│                       ├────────────────┤          │        │                   │                  ├─────────────────────────────────────────────────────────────┤
│                       │ CVE-2023-0215  │          │        │                   │                  │ openssl: use-after-free following BIO_new_NDEF              │
│                       │                │          │        │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-0215                   │
│                       ├────────────────┤          │        │                   │                  ├─────────────────────────────────────────────────────────────┤
│                       │ CVE-2023-0286  │          │        │                   │                  │ openssl: X.400 address type confusion in X.509 GeneralName  │
│                       │                │          │        │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-0286                   │
│                       ├────────────────┤          │        │                   ├──────────────────┼─────────────────────────────────────────────────────────────┤
│                       │ CVE-2023-0464  │          │        │                   │ 1.1.1t-r2        │ openssl: Denial of service by excessive resource usage in   │
│                       │                │          │        │                   │                  │ verifying X509 policy...                                    │
│                       │                │          │        │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-0464                   │
│                       ├────────────────┼──────────┤        │                   ├──────────────────┼─────────────────────────────────────────────────────────────┤
│                       │ CVE-2022-4304  │ MEDIUM   │        │                   │ 1.1.1t-r0        │ openssl: timing attack in RSA Decryption implementation     │
│                       │                │          │        │                   │                  │ https://avd.aquasec.com/nvd/cve-2022-4304                   │
│                       ├────────────────┤          │        │                   ├──────────────────┼─────────────────────────────────────────────────────────────┤
│                       │ CVE-2023-0465  │          │        │                   │ 1.1.1t-r2        │ openssl: Invalid certificate policies in leaf certificates  │
│                       │                │          │        │                   │                  │ are silently ignored                                        │
│                       │                │          │        │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-0465                   │
│                       ├────────────────┤          │        │                   ├──────────────────┼─────────────────────────────────────────────────────────────┤
│                       │ CVE-2023-2650  │          │        │                   │ 1.1.1u-r0        │ openssl: Possible DoS translating ASN.1 object identifiers  │
│                       │                │          │        │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-2650                   │
│                       ├────────────────┤          │        │                   ├──────────────────┼─────────────────────────────────────────────────────────────┤
│                       │ CVE-2023-3446  │          │        │                   │ 1.1.1u-r2        │ openssl: Excessive time spent checking DH keys and          │
│                       │                │          │        │                   │                  │ parameters                                                  │
│                       │                │          │        │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-3446                   │
│                       ├────────────────┤          │        │                   ├──────────────────┼─────────────────────────────────────────────────────────────┤
│                       │ CVE-2023-3817  │          │        │                   │ 1.1.1v-r0        │ OpenSSL: Excessive time spent checking DH q parameter value │
│                       │                │          │        │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-3817                   │
│                       ├────────────────┤          │        │                   ├──────────────────┼─────────────────────────────────────────────────────────────┤
│                       │ CVE-2023-5678  │          │        │                   │ 1.1.1w-r1        │ openssl: Generating excessively long X9.42 DH keys or       │
│                       │                │          │        │                   │                  │ checking excessively long X9.42...                          │
│                       │                │          │        │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-5678                   │
├───────────────────────┼────────────────┼──────────┤        │                   ├──────────────────┼─────────────────────────────────────────────────────────────┤
│ libssl1.1             │ CVE-2022-4450  │ HIGH     │        │                   │ 1.1.1t-r0        │ openssl: double free after calling PEM_read_bio_ex          │
│                       │                │          │        │                   │                  │ https://avd.aquasec.com/nvd/cve-2022-4450                   │
│                       ├────────────────┤          │        │                   │                  ├─────────────────────────────────────────────────────────────┤
│                       │ CVE-2023-0215  │          │        │                   │                  │ openssl: use-after-free following BIO_new_NDEF              │
│                       │                │          │        │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-0215                   │
│                       ├────────────────┤          │        │                   │                  ├─────────────────────────────────────────────────────────────┤
│                       │ CVE-2023-0286  │          │        │                   │                  │ openssl: X.400 address type confusion in X.509 GeneralName  │
│                       │                │          │        │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-0286                   │
│                       ├────────────────┤          │        │                   ├──────────────────┼─────────────────────────────────────────────────────────────┤
│                       │ CVE-2023-0464  │          │        │                   │ 1.1.1t-r2        │ openssl: Denial of service by excessive resource usage in   │
│                       │                │          │        │                   │                  │ verifying X509 policy...                                    │
│                       │                │          │        │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-0464                   │
│                       ├────────────────┼──────────┤        │                   ├──────────────────┼─────────────────────────────────────────────────────────────┤
│                       │ CVE-2022-4304  │ MEDIUM   │        │                   │ 1.1.1t-r0        │ openssl: timing attack in RSA Decryption implementation     │
│                       │                │          │        │                   │                  │ https://avd.aquasec.com/nvd/cve-2022-4304                   │
│                       ├────────────────┤          │        │                   ├──────────────────┼─────────────────────────────────────────────────────────────┤
│                       │ CVE-2023-0465  │          │        │                   │ 1.1.1t-r2        │ openssl: Invalid certificate policies in leaf certificates  │
│                       │                │          │        │                   │                  │ are silently ignored                                        │
│                       │                │          │        │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-0465                   │
│                       ├────────────────┤          │        │                   ├──────────────────┼─────────────────────────────────────────────────────────────┤
│                       │ CVE-2023-2650  │          │        │                   │ 1.1.1u-r0        │ openssl: Possible DoS translating ASN.1 object identifiers  │
│                       │                │          │        │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-2650                   │
│                       ├────────────────┤          │        │                   ├──────────────────┼─────────────────────────────────────────────────────────────┤
│                       │ CVE-2023-3446  │          │        │                   │ 1.1.1u-r2        │ openssl: Excessive time spent checking DH keys and          │
│                       │                │          │        │                   │                  │ parameters                                                  │
│                       │                │          │        │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-3446                   │
│                       ├────────────────┤          │        │                   ├──────────────────┼─────────────────────────────────────────────────────────────┤
│                       │ CVE-2023-3817  │          │        │                   │ 1.1.1v-r0        │ OpenSSL: Excessive time spent checking DH q parameter value │
│                       │                │          │        │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-3817                   │
│                       ├────────────────┤          │        │                   ├──────────────────┼─────────────────────────────────────────────────────────────┤
│                       │ CVE-2023-5678  │          │        │                   │ 1.1.1w-r1        │ openssl: Generating excessively long X9.42 DH keys or       │
│                       │                │          │        │                   │                  │ checking excessively long X9.42...                          │
│                       │                │          │        │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-5678                   │
├───────────────────────┼────────────────┼──────────┤        ├───────────────────┼──────────────────┼─────────────────────────────────────────────────────────────┤
│ ncurses-libs          │ CVE-2023-29491 │ HIGH     │        │ 6.3_p20211120-r1  │ 6.3_p20211120-r2 │ ncurses: Local users can trigger security-relevant memory   │
│                       │                │          │        │                   │                  │ corruption via malformed data                               │
│                       │                │          │        │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-29491                  │
├───────────────────────┤                │          │        │                   │                  │                                                             │
│ ncurses-terminfo-base │                │          │        │                   │                  │                                                             │
│                       │                │          │        │                   │                  │                                                             │
│                       │                │          │        │                   │                  │                                                             │
└───────────────────────┴────────────────┴──────────┴────────┴───────────────────┴──────────────────┴─────────────────────────────────────────────────────────────┘
```

